### PR TITLE
Implement async function support

### DIFF
--- a/tests/async_without_return.rs
+++ b/tests/async_without_return.rs
@@ -1,0 +1,8 @@
+use fn_error_context::context;
+
+#[context("context")]
+async fn async_something() {
+}
+
+fn main() {
+}

--- a/tests/async_without_return.stderr
+++ b/tests/async_without_return.stderr
@@ -1,0 +1,7 @@
+error: function should return Result
+ --> $DIR/async_without_return.rs:3:1
+  |
+3 | #[context("context")]
+  | ^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/inherent.rs
+++ b/tests/inherent.rs
@@ -7,6 +7,11 @@ impl Foo {
     fn do_stuff(&self) -> anyhow::Result<()> {
         anyhow::bail!("error {}", self.0)
     }
+
+    #[context("context")]
+    async fn do_async_stuff(&self) -> anyhow::Result<()> {
+        anyhow::bail!("error {}", self.0)
+    }
 }
 
 fn main() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,4 +15,5 @@ fn tests() {
     tests.compile_fail("tests/fmt_missing_arg.rs");
     tests.compile_fail("tests/fmt_unused_arg.rs");
     tests.pass("tests/fmt_named_arg.rs");
+    tests.compile_fail("tests/async_without_return.rs");
 }


### PR DESCRIPTION
Fixes #1 

Looks like async block behaves exactly as lambda for our use case (i.e. `return` and `?` work with the block scope).