### PR TITLE
Fix borrowing issues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub fn context(args: TokenStream, input: TokenStream) -> TokenStream {
             }
             syn::ReturnType::Type(_, return_ty) => {
                 input.block.stmts = syn::parse_quote!(
-                    let result: #return_ty = async { #body }.await;
+                    let result: #return_ty = async move { #body }.await;
                     result.map_err(|err| err.context(format!(#args)).into())
                 );
             }

--- a/tests/async_borrowing.rs
+++ b/tests/async_borrowing.rs
@@ -1,0 +1,9 @@
+use fn_error_context::context;
+
+#[context("context")]
+async fn borrows(val: &mut u32) -> anyhow::Result<&u32> {
+    Ok(&*val)
+}
+
+fn main() {
+}

--- a/tests/async_move.rs
+++ b/tests/async_move.rs
@@ -1,0 +1,8 @@
+use fn_error_context::context;
+
+#[context(move, "context")]
+async fn borrows(val: &mut u32) -> anyhow::Result<&u32> {
+    Ok(&*val)
+}
+
+fn main() {}

--- a/tests/async_no_move.rs
+++ b/tests/async_no_move.rs
@@ -1,0 +1,9 @@
+use fn_error_context::context;
+
+#[context("{}", context.as_ref())]
+async fn no_move(context: impl AsRef<str>) -> anyhow::Result<()> {
+    context.as_ref();
+    Ok(())
+}
+
+fn main() {}

--- a/tests/async_without_return.stderr
+++ b/tests/async_without_return.stderr
@@ -1,7 +1,6 @@
 error: function should return Result
- --> $DIR/async_without_return.rs:3:1
+ --> $DIR/async_without_return.rs:4:1
   |
-3 | #[context("context")]
-  | ^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
+4 | / async fn async_something() {
+5 | | }
+  | |_^

--- a/tests/borrowing.rs
+++ b/tests/borrowing.rs
@@ -1,7 +1,7 @@
 use fn_error_context::context;
 
 #[context("context")]
-async fn borrows(x: &mut u32) -> anyhow::Result<&mut u32> {
+fn borrows(x: &mut u32) -> anyhow::Result<&mut u32> {
     Ok(x)
 }
 

--- a/tests/borrowing.rs
+++ b/tests/borrowing.rs
@@ -1,8 +1,0 @@
-use fn_error_context::context;
-
-#[context("context")]
-fn borrows(x: &mut u32) -> anyhow::Result<&mut u32> {
-    Ok(x)
-}
-
-fn main() {}

--- a/tests/move.rs
+++ b/tests/move.rs
@@ -1,0 +1,8 @@
+use fn_error_context::context;
+
+#[context(move, "context")]
+fn foo(x: &mut u32) -> anyhow::Result<&u32> {
+    Ok(&*x)
+}
+
+fn main() {}

--- a/tests/no_move.rs
+++ b/tests/no_move.rs
@@ -1,0 +1,9 @@
+use fn_error_context::context;
+
+#[context("{}", context.as_ref())]
+fn no_move(context: impl AsRef<str>) -> anyhow::Result<()> {
+    context.as_ref();
+    Ok(())
+}
+
+fn main() {}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,7 +17,6 @@ fn tests() {
     tests.pass("tests/fmt_named_arg.rs");
     tests.compile_fail("tests/async_without_return.rs");
     tests.compile_fail("tests/preserve_lint.rs");
-    tests.pass("tests/borrowing.rs");
     tests.pass("tests/async_borrowing.rs");
     tests.pass("tests/no_move.rs");
     tests.pass("tests/async_no_move.rs");

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,4 +17,5 @@ fn tests() {
     tests.pass("tests/fmt_named_arg.rs");
     tests.compile_fail("tests/async_without_return.rs");
     tests.compile_fail("tests/preserve_lint.rs");
+    tests.pass("tests/async_borrowing.rs");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,5 +17,10 @@ fn tests() {
     tests.pass("tests/fmt_named_arg.rs");
     tests.compile_fail("tests/async_without_return.rs");
     tests.compile_fail("tests/preserve_lint.rs");
+    tests.pass("tests/borrowing.rs");
     tests.pass("tests/async_borrowing.rs");
+    tests.pass("tests/no_move.rs");
+    tests.pass("tests/async_no_move.rs");
+    tests.pass("tests/move.rs");
+    tests.pass("tests/async_move.rs");
 }


### PR DESCRIPTION
Previously, code like this would fail to compile:

```rust
#[context("context")]
async fn borrows(val: &mut u32) -> anyhow::Result<&u32> {
    Ok(&*val)
}
```

With this error message:

```
error[E0373]: async block may outlive the current function, but it borrows `val`, which is owned by the current function
 --> src/lib.rs:4:1
  |
4 | #[context("context")]
  | ^^^^^^^^^^^^^^^^^^^^^ may outlive borrowed value `val`
5 | async fn borrows(val: &mut u32) -> anyhow::Result<&u32> {
6 |     Ok(&*val)
  |          --- `val` is borrowed here
  |
note: async block is returned here
 --> src/lib.rs:4:1
  |
4 | #[context("context")]
  | ^^^^^^^^^^^^^^^^^^^^^
  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
help: to force the async block to take ownership of `val` (and any other referenced variables), use the `move` keyword
  |
4 | move #[context("context")]
  |
```

This can be fixed by using an `async move {}` block instead of an `async {}` block.